### PR TITLE
Change export files to use state postal code. Closes #161

### DIFF
--- a/warn/scrapers/ak.py
+++ b/warn/scrapers/ak.py
@@ -8,7 +8,7 @@ from warn.utils import write_rows_to_csv
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/alaska_warn_raw.csv'
+    output_csv = f'{output_dir}/ak.csv'
     url = 'https://jobs.alaska.gov/RR/WARN_notices.htm'
     page = requests.get(url)
     # Force encoding to fix dashes, apostrophes, etc. on page.text from requests reponse

--- a/warn/scrapers/al.py
+++ b/warn/scrapers/al.py
@@ -12,7 +12,7 @@ logger  = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = '{}/al.csv'.format(output_dir)
+    output_csv = f'{output_dir}/al.csv'
     url = 'https://www.madeinalabama.com/warn-list/'
     logger.debug(f'Scraping {url}')
     page = requests.get(url)

--- a/warn/scrapers/az.py
+++ b/warn/scrapers/az.py
@@ -10,7 +10,7 @@ logger  = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = '{}/arizona_warn_raw.csv'.format(output_dir)
+    output_csv = f'{output_dir}/az.csv'
     last_page_num = get_last_page_num()
     all_records = scrape_links(last_page_num)
     with open(output_csv, 'w') as csvfile:

--- a/warn/scrapers/ct.py
+++ b/warn/scrapers/ct.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = '{}/connecticut_warn_raw.csv'.format(output_dir)
+    output_csv = f'{output_dir}/ct.csv'
     years = [2021, 2020, 2019, 2018, 2017, 2016, 2015]
     header_row = ['warn_date','affected_company','layoff_location','number_workers','layoff_date','closing','closing_date','union','union_address']
     output_rows = []

--- a/warn/scrapers/de.py
+++ b/warn/scrapers/de.py
@@ -9,7 +9,7 @@ logger  = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/delaware_warn_raw.csv'
+    output_csv = f'{output_dir}/de.csv'
     last_page_num = get_last_page_num()
     all_records = scrape_links(last_page_num)
     with open(output_csv, 'w') as csvfile:

--- a/warn/scrapers/in.py
+++ b/warn/scrapers/in.py
@@ -8,7 +8,7 @@ logger  = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = '{}/indiana_warn_raw.csv'.format(output_dir)
+    output_csv = f'{output_dir}/in.csv'
     # max_entries = 378 # manually inserted
     # start_row_list = range(1, max_entries, 50)
     url1 = 'https://www.in.gov/dwd/2567.htm'

--- a/warn/scrapers/ks.py
+++ b/warn/scrapers/ks.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = '{}/kansas_warn_raw.csv'.format(output_dir)
+    output_csv = f'{output_dir}/ks.csv'
     last_page_num = get_last_page_num()
     all_records = scrape_links(last_page_num)
     with open(output_csv, 'w') as csvfile:

--- a/warn/scrapers/md.py
+++ b/warn/scrapers/md.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = '{}/maryland_warn_raw.csv'.format(output_dir)
+    output_csv = f'{output_dir}/md.csv'
     # max_entries = 378 # manually inserted
     years = range(2019, 2009, -1)
     url = 'http://www.dllr.state.md.us/employment/warn.shtml'

--- a/warn/scrapers/mt.py
+++ b/warn/scrapers/mt.py
@@ -4,6 +4,6 @@ import pandas as pd
 def scrape(output_dir, cache_dir=None):
     url = 'https://wsd.dli.mt.gov/_docs/wioa/warn.xlsx'
     df = pd.read_excel(url)
-    output_file = '{}/montana_warn_raw.csv'.format(output_dir)
+    output_file = f'{output_dir}/mt.csv'
     df.to_csv(output_file, index=False)
     return output_file

--- a/warn/scrapers/ne.py
+++ b/warn/scrapers/ne.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{cache_dir}/nebraska_warn_raw1.csv'
+    output_csv = f'{cache_dir}/ne_raw1.csv'
     years = range(2019, 2009, -1)
     url = 'https://dol.nebraska.gov/LayoffServices/WARNReportData/?year=2020'
     page = requests.get(url)
@@ -72,7 +72,7 @@ def scrape(output_dir, cache_dir=None):
 
 
 def nebraska_two(cache_dir):
-    output_csv = f'{cache_dir}/nebraska_warn_raw2.csv'
+    output_csv = f'{cache_dir}/ne_raw2.csv'
     years = range(2019, 2009, -1)
     url = 'https://dol.nebraska.gov/LayoffServices/LayoffAndClosureReportData/?year=2020'
     page = requests.get(url)
@@ -133,11 +133,11 @@ def nebraska_two(cache_dir):
 
 
 def combine(output_dir, cache_dir):
-    ne_one_path = f'{cache_dir}/nebraska_warn_raw1.csv'
-    ne_two_path = f'{cache_dir}/nebraska_warn_raw2.csv'
+    ne_one_path = f'{cache_dir}/ne_raw1.csv'
+    ne_two_path = f'{cache_dir}/ne_raw2.csv'
     ne_one = pd.read_csv(ne_one_path)
     ne_two = pd.read_csv(ne_two_path)
     ne_all_data = pd.concat([ne_one, ne_two])
-    output_csv = f'{output_dir}/nebraska_warn_raw.csv'
+    output_csv = f'{output_dir}/ne.csv'
     ne_all_data.to_csv(output_csv)
     return output_csv

--- a/warn/scrapers/nj.py
+++ b/warn/scrapers/nj.py
@@ -14,7 +14,7 @@ logger  = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/newjersey_warn_raw.csv'
+    output_csv = f'{output_dir}/nj.csv'
     url = 'http://lwd.state.nj.us/WorkForceDirectory/warn.jsp'
     logger.debug(f"Scraping {url}")
     html = scrape_page(url)

--- a/warn/scrapers/oh.py
+++ b/warn/scrapers/oh.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/ohio_warn_raw.csv'
+    output_csv = f'{output_dir}/oh.csv'
     url = 'https://jfs.ohio.gov/warn/current.stm'
     page = requests.get(url, verify=False)
     logger.debug(f"Page status is {page.status_code} for {url}")

--- a/warn/scrapers/ok.py
+++ b/warn/scrapers/ok.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/oklahoma_warn_raw.csv'
+    output_csv = f'{output_dir}/ok.csv'
     last_page_num = get_last_page_num()
     all_records = scrape_links(last_page_num)
     with open(output_csv, 'w') as csvfile:

--- a/warn/scrapers/or.py
+++ b/warn/scrapers/or.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def scrape(output_dir, cache_dir=None):
     # page range needs to be updated from 55 when there are enough notices for an additional page
     # as of 5/5/2020, this version of the scraper is fine
-    output_csv = f'{output_dir}/oregon_warn_raw.csv'
+    output_csv = f'{output_dir}/or.csv'
     # pages = range(1, 44, 1)
     pages = 1
     url = 'https://ccwd.hecc.oregon.gov/Layoff/WARN?page=1'

--- a/warn/scrapers/ri.py
+++ b/warn/scrapers/ri.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/rhodeisland_warn_raw.csv'
+    output_csv = f'{output_dir}/ri.csv'
     url = 'https://dlt.ri.gov/wds/warn/'
     page = requests.get(url)
     logger.debug(f"Page status is {page.status_code} for {url}")

--- a/warn/scrapers/sd.py
+++ b/warn/scrapers/sd.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/southdakota_warn_raw.csv'
+    output_csv = f'{output_dir}/sd.csv'
     url = 'https://dlr.sd.gov/workforce_services/businesses/warn_notices.aspx'
     page = requests.get(url)
     logger.debug(f"Page status is {page.status_code} for {url}")

--- a/warn/scrapers/va.py
+++ b/warn/scrapers/va.py
@@ -9,7 +9,7 @@ logger  = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/virginia_warn_raw.csv'
+    output_csv = f'{output_dir}/va.csv'
     url = 'https://www.vec.virginia.gov/warn-notices'
     response = requests.get(url)
     logger.debug(f"Page status is {response.status_code} for {url}")

--- a/warn/scrapers/wa.py
+++ b/warn/scrapers/wa.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/washington_warn_raw.csv'
+    output_csv = f'{output_dir}/wa.csv'
     # pages = range(2, 60, 1)
     page = 2
     url = 'https://fortress.wa.gov/esd/file/warn/Public/SearchWARN.aspx'

--- a/warn/scrapers/wi.py
+++ b/warn/scrapers/wi.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def scrape(output_dir, cache_dir=None):
-    output_csv = f'{output_dir}/wisconsin_warn_raw.csv'
+    output_csv = f'{output_dir}/wi.csv'
     years = [2016, 2017, 2018, 2019]
     url = 'https://sheets.googleapis.com/v4/spreadsheets/1cyZiHZcepBI7ShB3dMcRprUFRG24lbwEnEDRBMhAqsA/values/Originals?key=AIzaSyDP0OltIjcmRQ6-9TTmEVDZPIX6BSFcunw'
     response = requests.get(url)


### PR DESCRIPTION
Apply the 2-letter postal code [file-naming convention](https://github.com/biglocalnews/WARN#file-name-conventions) for exports to all states except for those currently in flight (MO and UT) /cc @shallotly 