### PR TITLE
Don't test PyPI publish in CI if secret unavailable

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -139,6 +139,9 @@ jobs:
       - id: publish
         name: Publish release
         uses: pypa/gh-action-pypi-publish@release/v1
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        if: env.PYPI_API_TOKEN != null
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
Adds the PyPI key as an environment variable on the step and then tests for its existence. Based on [this solution](https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/11).

Closes #369