### PR TITLE
Experiment with `attrs` class to define CSV outputs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,6 +31,7 @@ openpyxl = "*"
 pdfplumber = "*"
 tenacity = "*"
 click = "*"
+attrs = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a56d3002cf0f8b60694109af6d0c84aede0371f7eeb868119cf0baacb492da75"
+            "sha256": "de6bad8b739ea056288fe673d07dc97b7dc30d1adcff8f72dd175cf87c6891b5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+            ],
+            "index": "pypi",
+            "version": "==21.4.0"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf",
@@ -327,7 +335,7 @@
                 "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
                 "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "index": "pypi",
             "version": "==21.4.0"
         },
         "babel": {

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
         warn-scraper=warn.cli:main
     """,
     install_requires=[
+        "attrs",
         "click",
         "bs4",
         "html5lib",

--- a/warn/scrapers/ia.py
+++ b/warn/scrapers/ia.py
@@ -93,7 +93,7 @@ def scrape(
     data_path = data_dir / "ia.csv"
 
     # Write out the file
-    utils.write_rows_to_csv(data_path, row_list)
+    utils.write_notice_list(data_path, notice_list)
 
     # Return the path to the file
     return data_path


### PR DESCRIPTION
As my mind starting wandering toward the future challenge of standardization, I realized that, at some point, we're going to need to provide a mapping between the raw fields provided by our sources and the common clean fields of our consolidated file.

While that mapping is beyond the scope of this repository, which should stay limited to scraping, I had a thought. What if we provide a simple, loose schema for our source files within the scrapers?

This patch contains a test implementation using the `attrs` spin on dataclasses.

It has the following pros:
- We would explicitly document each source's headers in our code, making each state easier for a newbie to grok. 
- When the time comes to merge all the sources, we won't have to crack open CSV files to see what the source provides.
- The `attrs` system is loose and doesn't require any strict typing or changes to the raw data. We can flow it through without changing anything.
- We can standardize how we write out the CSV files using a utility like the one I've drafted here
- We can stop torturing ourselves by writing special case code to pluck out headers. Instead, we can define the expected headers in the class and then just skip header rows in the scrapes, as you see me do here.

Here are the cons I can think of:
- It's more code to write
- If there are cases where a source provides multiple files with different headers, I'm not sure what we'd do with this approach.

That's my musing. I'd love your take on this @zstumgoren. And @chriszs, I bet you'll have an opinion too. What do you think?