### PR TITLE
Extend flake8 ignore rules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 test=pytest
 
 [flake8]
-ignore = D100,D104,E203,E501
+extend-ignore = D100,D104,E203,E501


### PR DESCRIPTION
Default flake8 ignore rules were being overwritten leading to contradictory warnings. This extends the default rules instead.

Closes #381