### PR TITLE
Re-enable SSL verification for DE

### DIFF
--- a/warn/scrapers/de.py
+++ b/warn/scrapers/de.py
@@ -44,7 +44,6 @@ def scrape(
         stop_year,
         cache_dir,
         use_cache=use_cache,
-        verify=False,
     )
 
     # Return the resulting CSV file path


### PR DESCRIPTION
Re-enables SSL certificate verification for Delaware. The state's website now appears to have a valid SSL certificate and scraping appears to complete successfully without `verify=False`.

Closes #591 