### PR TITLE
Remove test release from deployment action

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -142,38 +142,6 @@ jobs:
           path: ./dist
           if-no-files-found: error
 
-  test-release:
-    name: Test PyPI release
-    runs-on: ubuntu-latest
-    needs: [test-build]
-    if: startsWith(github.ref, 'refs/tags') == 0
-    steps:
-      - id: setup-python
-        name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
-
-      - id: fetch
-        name: Fetch artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: test-release-${{ github.run_number }}
-          path: ./dist
-
-      - id: publish
-        name: Publish release
-        uses: pypa/gh-action-pypi-publish@release/v1
-        env:
-          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        if: env.PYPI_API_TOKEN != null
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-          verbose: true
-          verify_metadata: false
-
   tag-release:
     name: Tagged PyPI release
     runs-on: ubuntu-latest


### PR DESCRIPTION
My proposal to fix #662 is to remove the test PyPI deploy, which I don't think is necessary. This was overkill on my part.