### PR TITLE
Add Arkansas scraper

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,12 +1,13 @@
 # Sources
 
-There are currently scrapers for 39 of America's 56 states and territories.
+There are currently scrapers for 40 of America's 56 states and territories.
 
 | State | Source | Docs | Authors | Tags |
 | :---- | :----: | :--: | :------ | :--- |
 |[Alabama](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/al.py)|[🔗](https://www.madeinalabama.com/warn-list/)|[📃](scrapers/al.md)|[Dilcia19](https://github.com/Dilcia19), [zstumgoren](https://github.com/zstumgoren)|html|
 |[Alaska](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/ak.py)|[🔗](https://jobs.alaska.gov/RR/WARN_notices.htm)||[Dilcia19](https://github.com/Dilcia19), [zstumgoren](https://github.com/zstumgoren)|html|
 |[Arizona](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/az.py)|[🔗](https://www.azjobconnection.gov/search/warn_lookups/new)|[📃](scrapers/az.md)|[Dilcia19](https://github.com/Dilcia19), [zstumgoren](https://github.com/zstumgoren)|jobcenter|
+|[Arkansas](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/ar.py)|[🔗](https://www.arjoblink.arkansas.gov/search/warn_lookups/new)||[riordan](https://github.com/riordan)|jobcenter|
 |[California](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/ca.py)|[🔗](https://edd.ca.gov/en/Jobs_and_Training/Layoff_Services_WARN)|[📃](scrapers/ca.md)|[Dilcia19](https://github.com/Dilcia19), [ydoc5212](https://github.com/ydoc5212), [zstumgoren](https://github.com/zstumgoren)|excel, html, pdf|
 |[Colorado](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/co.py)|[🔗](https://cdle.colorado.gov/employers/layoff-separations/layoff-warn-list)|[📃](scrapers/co.md)|[anikasikka](https://github.com/anikasikka)|html|
 |[Connecticut](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/ct.py)|[🔗](https://www.ctdol.state.ct.us/progsupt/bussrvce/warnreports/warnreports.htm)||[Dilcia19](https://github.com/Dilcia19), [stucka](https://github.com/stucka), [zstumgoren](https://github.com/zstumgoren)|html|
@@ -47,9 +48,8 @@ There are currently scrapers for 39 of America's 56 states and territories.
 
 ## To do
 
-These 17 areas need a scraper:
+These 16 areas need a scraper:
 
-- Arkansas
 - Hawaii
 - Massachusetts
 - Minnesota

--- a/warn/scrapers/ar.py
+++ b/warn/scrapers/ar.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from warn.platforms.job_center.utils import scrape_state
+
+from .. import utils
+
+__authors__ = ["riordan"]
+__tags__ = ["jobcenter"]
+__source__ = {
+    "name": "Arkansas Division of Workforce Services",
+    "url": "https://www.arjoblink.arkansas.gov/search/warn_lookups/new",
+}
+
+
+def scrape(
+    data_dir: Path = utils.WARN_DATA_DIR,
+    cache_dir: Path = utils.WARN_CACHE_DIR,
+    use_cache: bool = True,
+) -> Path:
+    """
+    Scrape data from Arkansas.
+
+    Keyword arguments:
+    data_dir -- the Path were the result will be saved (default WARN_DATA_DIR)
+    cache_dir -- the Path where results can be cached (default WARN_CACHE_DIR)
+    use_cache -- a Boolean indicating whether the cache should be used (default True)
+
+    Returns: the Path where the file is written
+    """
+    output_csv = data_dir / "ar.csv"
+    search_url = "https://www.arjoblink.arkansas.gov/search/warn_lookups"
+    # Date chosen based on manual research
+    stop_year = 2007
+    # Use cache for years before current and prior year
+    scrape_state(
+        "AR", search_url, output_csv, stop_year, cache_dir, use_cache=use_cache
+    )
+    return output_csv
+
+
+if __name__ == "__main__":
+    scrape()


### PR DESCRIPTION
Closes #788.

Adds `warn/scrapers/ar.py` and updates `docs/sources.md`.

## How it works
Arkansas publishes WARN notices through an America's Job Link Alliance job center portal, so this reuses the shared `warn.platforms.job_center` code exactly like Kansas, Maine and Vermont — the scraper is just a thin wrapper supplying the search URL (https://www.arjoblink.arkansas.gov/search/warn_lookups) and a `stop_year`.

## Verification
Ran end-to-end against the live portal: it fetches, paginates and writes `ar.csv` with the standard job_center columns. The dataset is currently small — the state has posted only a few notices to the portal — but the scraper is correct and will pick up new notices as they're added.

## Note
`stop_year` is set to 2007; happy to adjust if maintainers have better records on how far back Arkansas's portal data goes.