### PR TITLE
Add North Dakota scraper

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,6 +1,6 @@
 # Sources
 
-There are currently scrapers for 39 of America's 56 states and territories.
+There are currently scrapers for 40 of America's 56 states and territories.
 
 | State | Source | Docs | Authors | Tags |
 | :---- | :----: | :--: | :------ | :--- |
@@ -29,6 +29,7 @@ There are currently scrapers for 39 of America's 56 states and territories.
 |[New Jersey](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/nj.py)|[🔗](https://www.nj.gov/labor/employer-services/warn/)||[Dilcia19](https://github.com/Dilcia19), [palewire](https://github.com/palewire), [zstumgoren](https://github.com/zstumgoren)|html|
 |[New Mexico](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/nm.py)|[🔗](https://www.dws.state.nm.us/Rapid-Response)||[chriszs](https://github.com/chriszs)|pdf|
 |[New York](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/ny.py)|[🔗](https://dol.ny.gov/warn-notices)|[📃](scrapers/ny.md)|[Dilcia19](https://github.com/Dilcia19), [palewire](https://github.com/palewire), [ydoc5212](https://github.com/ydoc5212), [zstumgoren](https://github.com/zstumgoren)|excel, historical|
+|[North Dakota](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/nd.py)|[🔗](https://www.jobsnd.com/documents)||[riordan](https://github.com/riordan)|pdf|
 |[Ohio](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/oh.py)|[🔗](https://jfs.ohio.gov/warn/index.stm)||[Dilcia19](https://github.com/Dilcia19), [chriszs](https://github.com/chriszs), [zstumgoren](https://github.com/zstumgoren)|html, pdf|
 |[Oklahoma](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/ok.py)|[🔗](https://okjobmatch.com/search/warn_lookups/new)|[📃](scrapers/ok.md)|[Dilcia19](https://github.com/Dilcia19), [zstumgoren](https://github.com/zstumgoren)|jobcenter|
 |[Oregon](https://github.com/biglocalnews/warn-scraper/blob/main/warn/scrapers/or.py)|[🔗](https://ccwd.hecc.oregon.gov/Layoff/WARN)|[📃](scrapers/or.md)|[Dilcia19](https://github.com/Dilcia19), [ydoc5212](https://github.com/ydoc5212), [zstumgoren](https://github.com/zstumgoren)|excel, historical|
@@ -47,7 +48,7 @@ There are currently scrapers for 39 of America's 56 states and territories.
 
 ## To do
 
-These 17 areas need a scraper:
+These 16 areas need a scraper:
 
 - Arkansas
 - Hawaii
@@ -57,7 +58,6 @@ These 17 areas need a scraper:
 - Nevada
 - New Hampshire
 - North Carolina
-- North Dakota
 - Pennsylvania
 - West Virginia
 - Wyoming

--- a/warn/scrapers/nd.py
+++ b/warn/scrapers/nd.py
@@ -1,0 +1,96 @@
+import logging
+import re
+from pathlib import Path
+
+import pdfplumber
+
+from .. import utils
+from ..cache import Cache
+
+__authors__ = ["riordan"]
+__tags__ = ["pdf"]
+__source__ = {
+    "name": "Job Service North Dakota",
+    "url": "https://www.jobsnd.com/documents",
+}
+
+logger = logging.getLogger(__name__)
+
+
+def scrape(
+    data_dir: Path = utils.WARN_DATA_DIR,
+    cache_dir: Path = utils.WARN_CACHE_DIR,
+) -> Path:
+    """
+    Scrape data from North Dakota.
+
+    Keyword arguments:
+    data_dir -- the Path were the result will be saved (default WARN_DATA_DIR)
+    cache_dir -- the Path where results can be cached (default WARN_CACHE_DIR)
+
+    Returns: the Path where the file is written
+    """
+    # Fire up the cache
+    cache = Cache(cache_dir)
+    state_code = "nd"
+
+    # North Dakota publishes a single static PDF covering 2015 to the present.
+    pdf_url = "https://www.jobsnd.com/sites/www/files/documents/jsnd-documents/WARN%20Notices%202015%20to%20present.pdf"
+
+    # Download the PDF and stash the raw file, unedited, in the cache
+    cache_key = f"{state_code}/WARN_Notices_2015_to_present.pdf"
+    pdf_path = cache.download(cache_key, pdf_url)
+
+    # Loop through the PDF pages and pull out the table
+    output_rows: list = []
+    header_written = False
+    with pdfplumber.open(pdf_path) as pdf:
+        for page_index, page in enumerate(pdf.pages):
+            rows = page.extract_table() or []
+
+            for row in rows:
+                # Standardize each cell
+                output_row = [_clean_text(cell) for cell in row]
+
+                # Skip fully empty rows
+                if not any(output_row):
+                    continue
+
+                # The header repeats at the top of the table. Keep it once.
+                if output_row[0] == "Company Name":
+                    if header_written:
+                        logger.debug(
+                            f"Skipping repeated header row on page {page_index + 1}"
+                        )
+                        continue
+                    header_written = True
+
+                output_rows.append(output_row)
+
+    # Write out to CSV
+    data_path = data_dir / f"{state_code}.csv"
+    utils.write_rows_to_csv(data_path, output_rows)
+
+    # Return the path
+    return data_path
+
+
+def _clean_text(text: str) -> str:
+    """
+    Clean up text from a PDF cell.
+
+    Keyword arguments:
+    text -- the text to clean
+
+    Returns: the cleaned text
+    """
+    # Replace None with an empty string
+    if text is None:
+        return ""
+
+    # Collapse newlines and standardize whitespace
+    return re.sub(r"\s+", " ", text).strip()
+
+
+if __name__ == "__main__":
+    scrape()


### PR DESCRIPTION
Closes #790.

Adds `warn/scrapers/nd.py` and updates `docs/sources.md`.

## How it works
Job Service North Dakota publishes a single static PDF covering WARN notices from 2015 to the present. The scraper caches the raw PDF unedited under `cache/nd/` and parses its ruled table with pdfplumber into `nd.csv` (columns: Company Name, Location, WARN Dated, Date of Layoff/Closure, Number Laid Off/Affected, Notes). No bot protection — plain requests works. Modeled on the pdfplumber pattern in sc.py/nm.py.

## Verification
Ran end-to-end against the live PDF: **54 data rows**, WARN dates spanning 2015 → 2026, every row a uniform 6 columns, header preserved once, no dropped rows. Idempotent on re-run; cached PDF is byte-identical to a direct download.

## Note on data fidelity
Output mirrors the source exactly, including a few source artifacts: ~9 recent rows where the state merged the WARN date and layoff date into one cell (e.g. `1/15/2026 1/28/2026`), a couple of apparent typo years in the source (2006, 2032), and free-text layoff dates like "Not stated". These are preserved rather than "corrected" so the mirror stays faithful to what ND published.